### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,36 +6,36 @@
 # Datatypes (KEYWORD1)
 #######################################
 WriteableIniFile	KEYWORD1
-error_t			KEYWORD1
+error_t	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setBuffer		KEYWORD2
-getLastName		KEYWORD2
-openSection		KEYWORD2
-nextSection		KEYWORD2
-getValueCopy		KEYWORD2
-getValue		KEYWORD2
-resetSection		KEYWORD2
-setValue		KEYWORD2
-printIni		KEYWORD2
-printJson		KEYWORD2
-getLastError		KEYWORD2
-resetError		KEYWORD2
-error			KEYWORD2
+setBuffer	KEYWORD2
+getLastName	KEYWORD2
+openSection	KEYWORD2
+nextSection	KEYWORD2
+getValueCopy	KEYWORD2
+getValue	KEYWORD2
+resetSection	KEYWORD2
+setValue	KEYWORD2
+printIni	KEYWORD2
+printJson	KEYWORD2
+getLastError	KEYWORD2
+resetError	KEYWORD2
+error	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-errorNoError		LITERAL1
+errorNoError	LITERAL1
 errorOutOfBuffer	LITERAL1
-errorFileSeek		LITERAL1
-errorFileRead		LITERAL1
-errorFileWrite		LITERAL1
-errorMalloc		LITERAL1
+errorFileSeek	LITERAL1
+errorFileRead	LITERAL1
+errorFileWrite	LITERAL1
+errorMalloc	LITERAL1
 errorInvalidParams	LITERAL1
 errorUnknownError	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords